### PR TITLE
Handle empty footprint history gracefully

### DIFF
--- a/wmiw.ebnnw.cn/Application/Home/Controller/IndexController.class.php
+++ b/wmiw.ebnnw.cn/Application/Home/Controller/IndexController.class.php
@@ -62,15 +62,32 @@ class IndexController extends CommonController {
             // 我的足迹【
             $goods = M('goods');
             $pidstr = M('member_footprint')->where(array('uid'=>$uid))->getField('pidstr');
-            // 字符串转换数组
-            $pidarr = unserialize($pidstr);
-            // 删除重复浏览的拍品
-            $pidarr = array_flip(array_flip($pidarr));
-            // 转换成字符串方便查询
-            $pidstr = implode(',', $pidarr);
-            $footprint = M('Auction')->where("pid in (".$pidstr.")")->where(array('hide'=>0))->order("field(pid,".$pidstr.")")->field('pid,gid,nowprice')->limit(50)->select();
-            foreach ($footprint as $ftkey => $ftvl) {
-                $footprint[$ftkey]['pictures']=$goods->where(array('id'=>$ftvl['gid']))->getField('pictures');
+            $footprint = array();
+            if ($pidstr) {
+                // 字符串转换数组
+                $pidarr = @unserialize($pidstr);
+                if (!is_array($pidarr)) {
+                    $pidarr = array();
+                }
+                if ($pidarr) {
+                    // 删除重复浏览的拍品
+                    $cleanPidarr = array();
+                    foreach ($pidarr as $pidItem) {
+                        if ($pidItem === '' || $pidItem === null) {
+                            continue;
+                        }
+                        $cleanPidarr[] = $pidItem;
+                    }
+                    $pidarr = array_values(array_unique($cleanPidarr));
+                    if ($pidarr) {
+                        // 转换成字符串方便查询
+                        $pidstr = implode(',', $pidarr);
+                        $footprint = M('Auction')->where("pid in (".$pidstr.")")->where(array('hide'=>0))->order("field(pid,".$pidstr.")")->field('pid,gid,nowprice')->limit(50)->select();
+                        foreach ($footprint as $ftkey => $ftvl) {
+                            $footprint[$ftkey]['pictures']=$goods->where(array('id'=>$ftvl['gid']))->getField('pictures');
+                        }
+                    }
+                }
             }
             $this->footprint=$footprint;
             // 我的足迹】


### PR DESCRIPTION
## Summary
- guard member footprint processing when no browsing history is stored
- keep footprint data empty rather than issuing invalid auction queries

## Testing
- php -l Application/Home/Controller/IndexController.class.php

------
https://chatgpt.com/codex/tasks/task_e_690013ce22f4832cb7a67fef6c4c9dea